### PR TITLE
window is displayed, but there are lots of errors in the console

### DIFF
--- a/console.nim
+++ b/console.nim
@@ -270,7 +270,7 @@ proc tabPressed*(c: Console; basePath: string) =
   if c.files.len == 0:
     # prefix == "..\..\foo"
     let (path, prefix) = c.prefix.splitPath
-    if path[0] == '~':
+    if path.len > 0 and path[0] == '~':
       let expandedPath = getHomeDir() / path.substr(1)
       for k, f in os.walkDir(expandedPath, relative=false):
         c.addFile f

--- a/nimedit.nim
+++ b/nimedit.nim
@@ -411,7 +411,7 @@ proc loadOpenTabs(ed: Editor) =
           let suggested = parseInt(x[2])
           ed.con.hist[key] = CmdHistory(cmds: @[], suggested: suggested)
         of "histval":
-          if not key.len == 0:
+          if key.len != 0:
             ed.con.hist[key].cmds.add x[1]
         else: discard
     else:

--- a/nimedit.nim
+++ b/nimedit.nim
@@ -411,8 +411,8 @@ proc loadOpenTabs(ed: Editor) =
           let suggested = parseInt(x[2])
           ed.con.hist[key] = CmdHistory(cmds: @[], suggested: suggested)
         of "histval":
-          doAssert(not key.len == 0)
-          ed.con.hist[key].cmds.add x[1]
+          if not key.len == 0:
+            ed.con.hist[key].cmds.add x[1]
         else: discard
     else:
       ed.sh.statusMsg = "cannot restore session; versions differ"
@@ -1125,7 +1125,7 @@ proc mainProc(ed: Editor) =
   let scriptContext = setupNimscript(sh.cfgColors)
   scriptContext.setupApi(sh)
   compileActions(sh.cfgActions)
-
+  
   loadTheme(sh)
   createSdlWindow(ed, 1u32)
 

--- a/nimedit.nims
+++ b/nimedit.nims
@@ -6,10 +6,8 @@ switch("path", "$lib/../")
 
 --threads:on
 
---define: booting
---define:useStdoutAsStdmsg
-when defined(windows):
-  --app:gui
+#when defined(windows):
+#  --app:gui
 
 #--noNimblePath
 

--- a/nimedit.nims
+++ b/nimedit.nims
@@ -6,8 +6,10 @@ switch("path", "$lib/../")
 
 --threads:on
 
-#when defined(windows):
-#  --app:gui
+--define:booting
+--define:useStdoutAsStdmsg
+when defined(windows):
+  --app:gui
 
 #--noNimblePath
 

--- a/nimscriptsupport.nim
+++ b/nimscriptsupport.nim
@@ -128,6 +128,8 @@ proc setupNimscript*(colorsScript: AbsoluteFile): PEvalContext =
   config.libpath = detectNimLib().AbsoluteDir
   add(config.searchPaths, config.libpath)
   add(config.searchPaths, AbsoluteDir(config.libpath.string / "pure"))
+  add(config.searchPaths, AbsoluteDir(config.libpath.string / "core"))
+  add(config.searchPaths, AbsoluteDir(config.libpath.string / "system"))
 
   initDefines(config.symbols)
   defineSymbol(config.symbols, "nimscript")

--- a/nimscriptsupport.nim
+++ b/nimscriptsupport.nim
@@ -113,8 +113,14 @@ proc detectNimLib(): string =
           result = nimexe.expandSymlink.splitPath()[0] /../ "lib"
         except OSError:
           result = getHomeDir() / ".choosenim/toolchains/nim-" & NimVersion / "lib"
-      if not fileExists(result / "system.nim"):
-        quit "cannot find Nim's stdlib location"
+        if not fileExists(result / "system.nim"):
+          quit "cannot find Nim's stdlib location"
+      elif defined(windows):
+        result = getHomeDir() / ".choosenim/toolchains/nim-" & NimVersion / "lib"
+        if not fileExists(result / "system.nim"):
+          quit "cannot find Nim's stdlib location"
+      else:
+        quit "Stdlib search unimplemented for this OS"
   when not defined(release): echo result
 
 proc setupNimscript*(colorsScript: AbsoluteFile): PEvalContext =


### PR DESCRIPTION
Tested on Windows and Linux and both display `NimEdit`, but there are a lot of errors in the right `console` window:
![image](https://user-images.githubusercontent.com/10289651/199792303-d1bb6f66-ee1d-4a9a-97f9-fa177b5c24fe.png)
```
C:\Users\matic\.choosenim\toolchains\nim-1.6.8\lib\pure\bitops.nim(28, 8) Error: cannot open file: macros
C:\Users\matic\.choosenim\toolchains\nim-1.6.8\lib\pure\bitops.nim(43, 12) Error: undeclared identifier: 'bindSym'
candidates (edit distance, scope distance); see '--spellSuggest': 
 (3, 4): 'binDir' [var declared in C:\Users\matic\.choosenim\toolchains\nim-1.6.8\lib\system\nimscript.nim(441, 5)]
C:\Users\matic\.choosenim\toolchains\nim-1.6.8\lib\pure\bitops.nim(43, 19) Error: attempting to call routine: 'bindSym'
  found 'bindSym' [unknown declared in C:\Users\matic\.choosenim\toolchains\nim-1.6.8\lib\pure\bitops.nim(43, 12)]
C:\Users\matic\.choosenim\toolchains\nim-1.6.8\lib\pure\bitops.nim(43, 19) Error: attempting to call routine: 'bindSym'
  found 'bindSym' [unknown declared in C:\Users\matic\.choosenim\toolchains\nim-1.6.8\lib\pure\bitops.nim(43, 12)]
C:\Users\matic\.choosenim\toolchains\nim-1.6.8\lib\pure\bitops.nim(43, 19) Error: expression 'bindSym' cannot be called
C:\Users\matic\.choosenim\toolchains\nim-1.6.8\lib\pure\bitops.nim(43, 19) Error: expression '' has no type (or is ambiguous)
C:\Users\matic\.choosenim\toolchains\nim-1.6.8\lib\pure\bitops.nim(43, 7) Error: 'let' symbol requires an initialization
C:\Users\matic\.choosenim\toolchains\nim-1.6.8\lib\pure\bitops.nim(44, 12) Error: undeclared identifier: 'newCall'
candidates (edit distance, scope distance); see '--spellSuggest': 
 (3, 4): 'readAll' [proc declared in C:\Users\matic\.choosenim\toolchains\nim-1.6.8\lib\system\io.nim(581, 6)]
C:\Users\matic\.choosenim\toolchains\nim-1.6.8\lib\pure\bitops.nim(44, 20) Error: expression 'fn' has no type (or is ambiguous)
C:\Users\matic\.choosenim\toolchains\nim-1.6.8\lib\pure\bitops.nim(44, 19) Error: attempting to call routine: 'newCall'
  found 'newCall' [unknown declared in C:\Users\matic\.choosenim\toolchains\nim-1.6.8\lib\pure\bitops.nim(44, 12)]
C:\Users\matic\.choosenim\toolchains\nim-1.6.8\lib\pure\bitops.nim(44, 19) Error: attempting to call routine: 'newCall'
  found 'newCall' [unknown declared in C:\Users\matic\.choosenim\toolchains\nim-1.6.8\lib\pure\bitops.nim(44, 12)]
... and many more lines of these errors
```
Could I get a hint please, of where to look to start fixing this?